### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files — @imaduranga must review and approve every PR before it can be merged
+* @imaduranga


### PR DESCRIPTION
Adds CODEOWNERS so that @imaduranga review is required on all PRs before merging to master.