### PR TITLE
TML11: enforce TML naming convention on issues and branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,30 @@
+name: TML Task
+description: Create a new task, feature, or bug fix. Branch names must match the issue number.
+title: "TML<number>: <short description>"
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Naming convention:** Replace `<number>` with this issue's number once created (e.g. `TML7: Add new feature`).
+        Your branch must then be named `TML<number>/short-slug` (e.g. `TML7/add-new-feature`).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this issue to be closed?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/workflows/naming-check.yml
+++ b/.github/workflows/naming-check.yml
@@ -1,0 +1,72 @@
+name: Naming Convention Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches: [master]
+  issues:
+    types: [opened, edited]
+
+jobs:
+  # ── Validate branch name on every PR targeting master ─────────────────────
+  check-branch:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Validate branch name and matching issue
+        env:
+          BRANCH: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Exempt automated branches (dependabot, chore/, docs/, release/)
+          if echo "$BRANCH" | grep -qE '^(dependabot/|chore/|docs/|release/)'; then
+            echo "Exempt branch pattern — skipping check."
+            exit 0
+          fi
+
+          # Branch must start with TML followed by one or more digits
+          if ! echo "$BRANCH" | grep -qE '^TML[0-9]+'; then
+            echo "::error::Branch '$BRANCH' must start with 'TML<number>' (e.g. TML6/my-feature). Create a GitHub issue first, then name the branch after its number."
+            exit 1
+          fi
+
+          # Extract the issue number
+          ISSUE_NUM=$(echo "$BRANCH" | grep -oE '^TML([0-9]+)' | grep -oE '[0-9]+')
+          echo "Issue number extracted: $ISSUE_NUM"
+
+          # Verify the issue exists in this repo
+          STATE=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.state' 2>/dev/null || echo "not_found")
+          if [ "$STATE" = "not_found" ]; then
+            echo "::error::Issue #${ISSUE_NUM} does not exist in ${REPO}. Create a GitHub issue titled 'TML${ISSUE_NUM}: <description>' before opening this PR."
+            exit 1
+          fi
+
+          echo "✓ Branch OK — linked to issue #${ISSUE_NUM} (state: ${STATE})"
+
+  # ── Validate issue title on every new/edited issue ─────────────────────────
+  check-issue-title:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Validate issue title starts with TML<number>
+        env:
+          TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if echo "$TITLE" | grep -qE '^TML[0-9]+'; then
+            echo "✓ Issue title follows naming convention."
+            exit 0
+          fi
+
+          gh issue comment "$ISSUE_NUM" --repo "$REPO" \
+            --body "⚠️ **Naming convention:** Issue titles must start with \`TML<number>:\` where the number matches the issue number (e.g. \`TML${ISSUE_NUM}: My feature description\`). Please edit the title to follow this convention before creating a branch."
+          echo "::warning::Issue #${ISSUE_NUM} title '$TITLE' does not follow the TML<number> naming convention."


### PR DESCRIPTION
Closes #11

- Adds `.github/workflows/naming-check.yml` — validates branch names on every PR (must start with `TML<number>` and reference a real issue); posts a warning comment on issues with non-compliant titles
- Adds `.github/ISSUE_TEMPLATE/task.yml` — pre-fills the `TML<number>: <description>` title format
- Exempt branches: `master`, `staging`, `dependabot/**`, `chore/**`, `docs/**`, `release/**`

> Note: GitHub `branch_name_pattern` rulesets require GitHub Enterprise — enforcement is via the CI check instead.